### PR TITLE
Simplifie la gestion des paramètres DH

### DIFF
--- a/openvpn/tasks/main.yml
+++ b/openvpn/tasks/main.yml
@@ -35,18 +35,16 @@
     mode: '0700'
   tags: openvpn, keys
 
+- name: generate dhparams
+  shell: openssl dhparam -out /usr/local/etc/openvpn/keys/dh.pem 2048
+  creates: /usr/local/etc/openvpn/keys/dh.pem
+  tags: openvpn, config
+
 - name: check dhparam
   file:
     dest: /usr/local/etc/openvpn/keys/dh.pem
     state: file
     mode: '0600'
-  register: dhfile
-  failed_when: False
-  tags: openvpn, config
-
-- name: generate dhparams
-  shell: openssl dhparam -out /usr/local/etc/openvpn/keys/dh.pem 2048
-  when: dhfile.state == "absent"
   tags: openvpn, config
 
 - name: copy openvpn state files


### PR DESCRIPTION
L'attribut `creates` du module `shell` (comme `command`, cf. http://docs.ansible.com/ansible/command_module.html#notes) permet d'indiquer qu'il est censé créer le fichier en question et donc ne le jouera pas la commande s'il existe déjà.

On peut alors déplacer l'action qui force les droits sur le fichier juste après et retirer l'enregistrement de la variabble `dhfile`.