### PR TITLE
Utiliser le module sysctl

### DIFF
--- a/openvpn/handlers/main.yml
+++ b/openvpn/handlers/main.yml
@@ -4,6 +4,3 @@
     name: 'openvpn{{ item }}'
     state: restarted
   with_items: '{{ openvpn_configs }}'
-
-- name: disable hw csum on kvm
-  command: 'sysctl hw.vtnet.csum_disable=1'

--- a/openvpn/tasks/main.yml
+++ b/openvpn/tasks/main.yml
@@ -76,13 +76,14 @@
   notify: restart openvpn
 
 - name: sysctl if kvm
-  lineinfile:
-    file: /etc/sysctl.conf
-    line: 'hw.vtnet.csum_disable=1'
-    regexp: '^hw.vtnet.csum_disable'
+  sysctl:
+    sysctl_file: /etc/sysctl.conf
+    name: hw.vtnet.csum_disable
+    value: 1
     state: present
+    sysctl_set: yes
+    reload: yes
   when: ansible_default_ipv4.device == "vtnet0"
-  notify: disable hw csum on kvm
 
 - name: start openvpn
   service:


### PR DESCRIPTION
Plutôt qu'utiliser un `lineinfile`, il est possible d'utiliser directement le module `sysctl`.

Il faut vérifier le comportement attendu par rapport aux attributs `reload` (qui recharge le fichier) et `sysctl_set` (qui, a priori,  exécute la commande manuellement pour appliquer la valeur).